### PR TITLE
[HOPSWORKS-923] Availability Zone Awareness support for HopsFS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -117,12 +117,18 @@ default['ndb']['base_dir']                            = "#{node['ndb']['root_dir
 
 default['ndb']['InitialLogFileGroup']                 = "undo_buffer_size=128M; "
 # NDB Cluster Disk Data data files and undo log files are placed in the diskdata_dir directory
-default['ndb']['diskdata_dir']                        = "#{node['ndb']['root_dir']}/ndb_disk_columns"
+default['ndb']['ndb_disk_columns_dir_name']           = "ndb_disk_columns"
+default['ndb']['diskdata_dir']                        = "#{node['ndb']['root_dir']}/#{node['ndb']['ndb_disk_columns_dir_name']}"
 default['ndb']['nvme']['small_file']                  = "2000"
 default['ndb']['nvme']['med_file']                    = "4000"
 default['ndb']['nvme']['large_file']                  = "8000"
 default['ndb']['nvme']['logfile_size']                = ""
 default['ndb']['nvme']['num_logfiles']                = ""
+
+default['ndb']['nvme']['mount_base_dir']              = "/mnt/nvmeDisks"
+default['ndb']['nvme']['mount_disk_prefix']           = "nvme"
+default['ndb']['nvme']['disks']                       = []
+default['ndb']['nvme']['format']                      = "false"
 
 default['ndb']['BackupDataDir']                       = "#{node['ndb']['root_dir']}/ndb/backups"
 
@@ -140,6 +146,7 @@ default['ndb']['mgm_dir']                             = "#{node['ndb']['root_dir
 # MySQL Server Parameters
 default['ndb']['mysql_server_dir']                    = "#{node['ndb']['root_dir']}/mysql"
 default['ndb']['num_ndb_slots_per_client']            = 1
+default['ndb']['num_ndb_slots_per_mysqld']            = 1
 
 # Max time that the mysqld and memcached will wait for the MySQL Cluster to be up and running.
 # If the mysqld or memcached starts and the MySQL Cluster isn't running, it will not connect and will
@@ -226,3 +233,8 @@ default['ndb']['backup_time']                         = "03:00"
 
 default['ndb']['systemd']                             = node['systemd']
 
+
+#LocationDomainId
+default['ndb']['mgmd']['private_ips_domainIds']          = {}
+default['ndb']['ndbd']['private_ips_domainIds']          = {}
+default['ndb']['mysqld']['private_ips_domainIds']        = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -279,7 +279,7 @@ attribute "ndb/NoOfFragmentLogParts",
           :type => 'string'
 
 attribute "ndb/NoOfFragmentLogFiles",
-          :description =>  "Number of fragment logfiles for writing LCPS.", 
+          :description =>  "Number of fragment logfiles for writing LCPS.",
           :type => 'string'
 
 attribute "ndb/bind_cpus",
@@ -348,22 +348,25 @@ attribute "ndb/mysqld/ips_ids",
           :description =>  "The format should be ['ip1:id1', 'ip2:id2', ...] for the mysql section in the config.ini file. If no value is supplied, one will be assigned by default.",
           :type => 'array'
 
-attribute "ndb/MaxNoOfExecutionThreads",
-          :description => "Number of execution threads for MySQL Cluster",
-          :type => 'string'
-
-attribute "ndb/DataMemory",
-          :description => "Data memory for each MySQL Cluster Data Node",
-          :type => 'string',
-          :required => "required"
-
-attribute "ndb/IndexMemory",
-          :description => "Index memory for each MySQL Cluster Data Node",
-          :type => 'string'
-
 attribute "ndb/EnableRedoControl",
           :description => "Control disk read/write speeds automatically for LCPs (default '1', to turn off - set to '0'",
           :type => 'string'
+
+attribute "ndb/mgmd/private_ips_domainIds",
+          :description => "private_ips to LocationDomainIds for ndb_mgmds",
+          :type => 'array'
+
+attribute "ndb/ndbd/private_ips_domainIds",
+          :description => "private_ips to LocationDomainIds for ndb data nodes",
+          :type => 'hash'
+
+attribute "ndb/mysqld/private_ips_domainIds",
+          :description => "private_ips to LocationDomainIds mapping for mysql servers",
+          :type => 'hash'
+
+attribute "ndb/ndbapi/private_ips_domainIds",
+          :description => "LocationDomainIds for ndb api nodes (namenodes)",
+          :type => 'hash'
 
 attribute "install/dir",
           :description => "Set to a base directory under which we will install.",
@@ -381,6 +384,22 @@ attribute "services/enabled",
           :description => "Default 'false'. Set to 'true' to enable daemon services, so that they are started on a host restart.",
           :type => "string"
 
+attribute "ndb/nvme/disks",
+          :description => "NVMe disks to use for the on disk columns. This configuration overides ndb/diskdata_dir",
+          :type => "array"
+
+attribute "ndb/nvme/format",
+          :description => "Default 'false'. Set to 'true' to format the NVMe disks specified in ndb/nvme/disks.",
+          :type => "string"
+
+attribute "ndb/num_ndb_slots_per_client",
+          :description => "Number of NDB connection slots per api node",
+          :type => "string"
+
+attribute "ndb/num_ndb_slots_per_mysqld",
+          :description => "Number of NDB connection slots per mysqld node",
+          :type => "string"
+
 # attribute "btsync/ndb/seeder_secret",
 # :display_name => "Ndb seeder's random secret key.",
 # :description => "20 chars or more (normally 32 chars)",
@@ -392,4 +411,3 @@ attribute "services/enabled",
 # :description => "Ndb's random secret (key) generated using the seeder's secret key. 20 chars or more (normally 32 chars)",
 # :type => 'string',
 # :default => "BTHKJKK4PIPIOJZ7GITF2SJ2IYDLSSJVY"
-

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -81,14 +81,6 @@ directory node['ndb']['BackupDataDir'] do
   action :create
 end
 
-directory node['ndb']['diskdata_dir'] do
-  owner node['ndb']['user']
-  group node['ndb']['group']
-  mode "750"
-  action :create
-end
-
-
 directory node['mysql']['version_dir'] do
   owner node['ndb']['user']
   group node['ndb']['group']

--- a/recipes/mgmd.rb
+++ b/recipes/mgmd.rb
@@ -69,23 +69,6 @@ template "#{node['ndb']['scripts_dir']}/native_ndb_backup.sh" do
 end
 
 #
-# These are helper scripts for exapnding tables with on-disk columns
-#
-template "#{node['ndb']['scripts_dir']}/manage-disk-table.py" do
-    source "manage-disk-table.py.erb"
-    owner node['ndb']['user']
-    group node['ndb']['group']
-    mode 0700
-end
-
-template "#{node['ndb']['scripts_dir']}/create-disk-table.sh" do
-    source "create-disk-table.sh.erb"
-    owner node['ndb']['user']
-    group node['ndb']['group']
-    mode 0700
-end
-
-#
 # Install cron backup job on the node with the first ndb_mgmd
 #
 if found_id == node['mgm']['id'] && "#{node['ndb']['cron_backup']}" == "true"
@@ -180,6 +163,11 @@ end
 # Need to call get_ndbapi_addrs to set them before instantiating config.ini
 get_ndbapi_addrs()
 
+diskDataDir=node['ndb']['diskdata_dir']
+if !node['ndb']['nvme']['disks'].empty?
+  diskDataDir="#{node['ndb']['nvme']['mount_base_dir']}/#{node['ndb']['nvme']['mount_disk_prefix']}0/#{node['ndb']['ndb_disk_columns_dir_name']}"
+end
+
 template "#{node['ndb']['root_dir']}/config.ini" do
   source "config.ini.erb"
   owner node['ndb']['user']
@@ -187,7 +175,9 @@ template "#{node['ndb']['root_dir']}/config.ini" do
   mode 0644
   action :create_if_missing
   variables({
-              :num_client_slots => node['ndb']['num_ndb_slots_per_client'].to_i
+              :num_ndb_slots_per_client => node['ndb']['num_ndb_slots_per_client'].to_i,
+              :num_ndb_slots_per_mysqld => node['ndb']['num_ndb_slots_per_mysqld'].to_i,
+              :diskDataDir => diskDataDir
             })
 end
 

--- a/templates/default/config.ini.erb
+++ b/templates/default/config.ini.erb
@@ -203,20 +203,25 @@ MinDiskWriteSpeed=<%= node['ndb']['MinDiskWriteSpeed'] %>
 OverloadLimit=<%= node['ndb']['OverloadLimit'] %>
 
 #
-# Supports up to Max 2 ndb_mgmds. First one gets ArbitrationRank=1, second gets lower priority ArbitrationRank=2
+# Supports up to Max 3 ndb_mgmds. First one gets ArbitrationRank=1, others gets lower priority ArbitrationRank=2
 #
 <% id = node['mgm']['id'] -%>
-<% rank = 1 -%>
+<% index = 1 -%>
 <% for mgmd in node['ndb']['mgmd']['private_ips'] -%>
 [NDB_MGMD]
 NodeId=<%= id %>
+<% if (node.attribute?(:ndb) && node['ndb'].attribute?(:mgmd) && node['ndb']['mgmd'].attribute?(:private_ips_domainIds) && node['ndb']['mgmd']['private_ips_domainIds'].has_key?(mgmd)) -%>
+LocationDomainId=<%= node['ndb']['mgmd']['private_ips_domainIds'][mgmd] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= mgmd %>
 PortNumber=<%= node['ndb']['mgmd']['port'] %>
 DataDir=<%= node['ndb']['log_dir'] %>
 LogDestination=FILE:filename=<%= node['ndb']['log_dir'] %>/cluster.log,maxsize=10000000,maxfiles=6
-ArbitrationRank=<%= rank %>
+ArbitrationRank=<%= index == 1 ? 1 : 2%>
 <% id += 1 -%>
-<% rank += 1 -%>
+<% index += 1 -%>
 <% end -%>
 
 <% id = 1 -%>
@@ -226,11 +231,16 @@ ArbitrationRank=<%= rank %>
 <% theNode = datanode.split(":") -%>
 [NDBD] 
 NodeId=<%= theNode[1] %>
+<% if (node.attribute?(:ndb) && node['ndb'].attribute?(:ndbd) && node['ndb']['ndbd'].attribute?(:private_ips_domainIds) && node['ndb']['ndbd']['private_ips_domainIds'].has_key?(theNode[0])) -%>
+LocationDomainId=<%= node['ndb']['ndbd']['private_ips_domainIds'][theNode[0]] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= theNode[0] %>
 ServerPort=<%= node['ndb']['ndbd']['port'] %>
 DataDir=<%= node['ndb']['log_dir'] %>
 FileSystemPath=<%= "#{node['ndb']['data_dir']}/#{theNode[1]}" %>
-FileSystemPathDD=<%= "#{node['ndb']['diskdata_dir']}/#{theNode[1]}" %>
+FileSystemPathDD=<%= @diskDataDir %>
 BackupDataDir=<%= node['ndb']['BackupDataDir'] %>
 <% end -%>
 
@@ -238,11 +248,16 @@ BackupDataDir=<%= node['ndb']['BackupDataDir'] %>
 <% for ndbdNode in node['ndb']['ndbd']['private_ips'] -%>
 [NDBD] 
 NodeId=<%= id %>
+<% if (node.attribute?(:ndb) && node['ndb'].attribute?(:ndbd) && node['ndb']['ndbd'].attribute?(:private_ips_domainIds) && node['ndb']['ndbd']['private_ips_domainIds'].has_key?(ndbdNode)) -%>
+LocationDomainId=<%= node['ndb']['ndbd']['private_ips_domainIds'][ndbdNode] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= ndbdNode %>
 ServerPort=<%= node['ndb']['ndbd']['port'] %>
 DataDir=<%= node['ndb']['log_dir'] %>
 FileSystemPath=<%= "#{node['ndb']['data_dir']}/#{id}" %>
-FileSystemPathDD=<%= "#{node['ndb']['diskdata_dir']}/#{id}" %>
+FileSystemPathDD=<%= @diskDataDir %>
 BackupDataDir=<%= node['ndb']['BackupDataDir'] %>
 <% id += 1 -%>
 <% end -%>
@@ -250,13 +265,17 @@ BackupDataDir=<%= node['ndb']['BackupDataDir'] %>
 <% end -%>
 
 #MySQL Servers, Memcached servers, and Clusterj clients.
-
 <% if (node.attribute?('ndb') && node['ndb'].attribute?('mysqld') && node['ndb']['mysqld'].attribute?(:ips_ids) && !node['ndb']['mysqld']['ips_ids'].empty?) -%>
 
 <% for mysqld in node['ndb']['mysqld']['ips_ids'] -%>
 <% theMysqld = mysqld.split(":") -%>
 [MYSQLD]
 NodeId=<%= theMysqld[1] %>
+<% if (node.attribute?(:ndb) && node['ndb'].attribute?(:mysqld) && node['ndb']['mysqld'].attribute?(:private_ips_domainIds) && node['ndb']['mysqld']['private_ips_domainIds'].has_key?(theMysqld[0])) -%>
+LocationDomainId=<%= node['ndb']['mysqld']['private_ips_domainIds'][theMysqld[0]] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= theMysqld[0] %>
 <% end -%>
 
@@ -265,12 +284,22 @@ HostName=<%= theMysqld[0] %>
 <% hostId = node['mysql']['id'] -%>
 <% if (node.attribute?(:ndb) && node['ndb'].attribute?(:mysqld) && node['ndb']['mysqld'].attribute?(:private_ips) && !node['ndb']['mysqld']['private_ips'].empty?) -%>
 <% for mysql in node['ndb']['mysqld']['private_ips'] -%>
-# for count in 0..(@num_client_slots-1)
+
+<% for count in 1..@num_ndb_slots_per_mysqld -%>
 [MYSQLD]
 NodeId=<%= hostId %>
+<% if (node.attribute?(:ndb) && node['ndb'].attribute?(:mysqld) && node['ndb']['mysqld'].attribute?(:private_ips_domainIds) && node['ndb']['mysqld']['private_ips_domainIds'].has_key?(mysql)) -%>
+LocationDomainId=<%= node['ndb']['mysqld']['private_ips_domainIds'][mysql] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= mysql %>
 <% hostId += 1 -%>
+
 <% end -%>
+
+<% end -%>
+
 <% end -%>
 
 <% end -%>
@@ -278,69 +307,25 @@ HostName=<%= mysql %>
 <% hostId = node['nn']['id'] -%>
 <% if (node.attribute?(:hops) && node['hops'].attribute?(:nn) && node['hops']['nn'].attribute?(:private_ips) && !node['hops']['nn']['private_ips'].empty?) -%>
 <% for nn in node['hops']['nn']['private_ips'] -%>
-[MYSQLD]
+
+<% for count in 1..@num_ndb_slots_per_client -%>
+[API]
 NodeId=<%= hostId %>
+<% if (node.attribute?(:hops) && node['hops'].attribute?(:nn) && node['hops']['nn'].attribute?(:private_ips_domainIds) && node['hops']['nn']['private_ips_domainIds'].has_key?(nn)) -%>
+LocationDomainId=<%= node['hops']['nn']['private_ips_domainIds'][nn] %>
+<% else -%>
+LocationDomainId=0
+<% end -%>
 HostName=<%= nn %>
 <% hostId += 1 -%>
+
+<% end -%>
 <% end -%>
 <% end -%>
 
 # These slots are extra slots for any clients.
 # Remove these slots for production use.
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
-[MYSQLD]
+
+<% for id in hostId..255 -%>
+[API]
+<% end -%>

--- a/templates/default/drop-disk-table.sh.erb
+++ b/templates/default/drop-disk-table.sh.erb
@@ -5,4 +5,4 @@ username=<%= node['mysql']['user']  %>
 password=<%= node['mysql']['password'] %>
 database=<%= node.attribute?(:hops) && node['ndb'].attribute?(:db) ? node['hops']['db'] : "hops" %>
 
-<%= node['ndb']['scripts_dir'] %>/manage-disk-table.py -Create -H $host -u $username -p $password -db $database -ls 1024M -lc 1 -ds 1024M -dc 1
+<%= node['ndb']['scripts_dir'] %>/manage-disk-table.py -Drop -H $host -u $username -p $password -db $database -ls 1024M -lc 1 -ds 1024M -dc 1

--- a/templates/default/manage-disk-table.py.erb
+++ b/templates/default/manage-disk-table.py.erb
@@ -20,15 +20,15 @@ group.add_argument('-Drop', action='store_true', dest="drop", help="Drop Files a
 args = parser.parse_args()
 print args
 
-#DATA_DISKS = ["/dir1,/dir2"]
-DATA_DISKS = ["<%= node['ndb']['NvmeDisks'] %>"]
-DATAFILE_SIZE = args.dataFileSize 
-DATAFILES_PER_DISK = args.dataFilesCount 
+#DATA_DISKS = ["/dir1","/dir2"]
+DATA_DISKS = <%= @nvmeDisksDataDirs %>
+DATAFILE_SIZE = args.dataFileSize
+DATAFILES_PER_DISK = args.dataFilesCount
 
-#LOG_DISKS = ["/dir1,/dir2"]
-LOG_DISKS = ["<%= node['ndb']['LogDisks'] %>"]
+#LOG_DISKS = ["/dir1","/dir2"]
+LOG_DISKS = <%= @nvmeDisksDataDirs %>
 LOGFILE_SIZE = args.logFileSize
-LOGFILES_PER_DISK = args.logFilesCount 
+LOGFILES_PER_DISK = args.logFilesCount
 
 CONNECT_STRING = "MYSQL_PWD="+args.passwd+" mysql -u"+args.userName+" -P"+args.port+" -h "+args.host+" "+args.database+" -e "
 print CONNECT_STRING
@@ -89,18 +89,18 @@ def create():
       if tableSpaceCreated == False:
         printStage("Creating Table Space")
         tableSpaceCreated = True
-        subCommand = ("CREATE TABLESPACE %s ADD datafile '%s%s_data_file_%d.dat' use LOGFILE GROUP lg_1 INITIAL_SIZE = %s  ENGINE ndbcluster" % (TS_NAME, TS_NAME, disk, fileIndex, DATAFILE_SIZE))
+        subCommand = ("CREATE TABLESPACE %s ADD datafile '%s%s_data_file_%d.dat' use LOGFILE GROUP lg_1 INITIAL_SIZE = %s  ENGINE ndbcluster" % (TS_NAME, disk, TS_NAME, fileIndex, DATAFILE_SIZE))
       else:
-        subCommand = ("ALTER TABLESPACE %s ADD datafile '%s%s_data_file_%d.dat' INITIAL_SIZE = %s  ENGINE ndbcluster" % (TS_NAME, TS_NAME, disk, fileIndex, DATAFILE_SIZE))
+        subCommand = ("ALTER TABLESPACE %s ADD datafile '%s%s_data_file_%d.dat' INITIAL_SIZE = %s  ENGINE ndbcluster" % (TS_NAME, disk, TS_NAME, fileIndex, DATAFILE_SIZE))
       executeSQLCommand(subCommand)
 
   #Create Table
   printStage("Creating Tables")
-  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_small_file_inode_data ( inode_id int(11) PRIMARY KEY, data varbinary(%d) not null ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (\`inode_id\`)"% (ONDISK_SMALL_FILE_INODE_SIZE, TS_NAME))
+  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_small_file_inode_data ( inode_id bigint(20) PRIMARY KEY, data varbinary(%d) not null ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (\`inode_id\`)"% (ONDISK_SMALL_FILE_INODE_SIZE, TS_NAME))
   executeSQLCommand(subCommand)
-  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_medium_file_inode_data ( inode_id int(11) PRIMARY KEY, data varbinary(%d) not null ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (\`inode_id\`)"% (ONDISK_MEDIUM_FILE_INODE_SIZE, TS_NAME))
+  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_medium_file_inode_data ( inode_id bigint(20) PRIMARY KEY, data varbinary(%d) not null ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (\`inode_id\`)"% (ONDISK_MEDIUM_FILE_INODE_SIZE, TS_NAME))
   executeSQLCommand(subCommand)
-  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_large_file_inode_data ( inode_id int(11), dindex int(11), data varbinary(%d) not null,  PRIMARY KEY(inode_id, dindex) ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (inode_id)"% (ONDISK_LARGE_FILE_INODE_SIZE, TS_NAME))
+  subCommand = ("CREATE TABLE IF NOT EXISTS hdfs_ondisk_large_file_inode_data ( inode_id bigint(20), dindex int(11), data varbinary(%d) not null,  PRIMARY KEY(inode_id, dindex) ) TABLESPACE %s STORAGE DISK ENGINE ndbcluster COMMENT='NDB_TABLE=READ_BACKUP=1' partition by key (inode_id)"% (ONDISK_LARGE_FILE_INODE_SIZE, TS_NAME))
   executeSQLCommand(subCommand)
 
 
@@ -119,7 +119,7 @@ def drop():
       if disk and not disk.endswith('/'):
         disk+="/"
 
-      subCommand = ("ALTER TABLESPACE %s drop datafile '%s%s_data_file_%d.dat' ENGINE ndbcluster" % (TS_NAME, TS_NAME, disk, fileIndex))
+      subCommand = ("ALTER TABLESPACE %s drop datafile '%s%s_data_file_%d.dat' ENGINE ndbcluster" % (TS_NAME, disk, TS_NAME, fileIndex))
       executeSQLCommand(subCommand)
 
   subCommand = ("DROP TABLESPACE %s ENGINE ndbcluster"%(TS_NAME))
@@ -141,9 +141,3 @@ if __name__ == "__main__":
 
     elif args.drop:
         drop()
-        
-
-
-
-        
-

--- a/templates/default/my-ndb.cnf.erb
+++ b/templates/default/my-ndb.cnf.erb
@@ -44,7 +44,7 @@ optimizer_switch=engine_condition_pushdown=on
 ndb-join-pushdown=1
 
 # use the cluster connection pool to reduce cluster connection setup time
-ndb-cluster-connection-pool=<%= node['ndb']['num_ndb_slots_per_client'] %>
+ndb-cluster-connection-pool=<%= node['ndb']['num_ndb_slots_per_mysqld'] %>
 
 # Log more data at MySQL Server about ndb
 ndb-extra-logging=0


### PR DESCRIPTION
Added locationdomainId for mgmd, ndbd, mysqld, and ndbapi nodes
Added support for mounting and formating NVMe disks for smallfiles

Tests: https://github.com/logicalclocks/hops-testing/pull/285

**Notes** 
This pull request is dependent on the new changes in Karamel to assign a locationDomainId to each ip, however, it is backward compatible, if no locationDomainId is provided, it will use the default value 0.
