### PR TITLE
[HOPSWORKS-2626] MySQL timezone issue

### DIFF
--- a/recipes/mysqld.rb
+++ b/recipes/mysqld.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 ndb_connectstring()
 
 case node['platform_family']
@@ -69,7 +71,8 @@ template "#{node['ndb']['root_dir']}/my.cnf" do
    :mysql_id => found_id,
    # Here is always false, as this recipe is run before certificates are available
    # if mysql/tls is enabled, the file will be re-templated later
-   :mysql_tls => false
+   :mysql_tls => false,
+   :timezone => Time.now.strftime("%:z")
   })
   if node['services']['enabled'] == "true"
     notifies :enable, resources(:service => service_name), :immediately

--- a/recipes/mysqld_tls.rb
+++ b/recipes/mysqld_tls.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 # This recipe is here to reconfigure the MySQL server to use TLS (if TLS is enabled)
 # It cannot be done in the mysqld.rb recipe as we need MySQL to start Hopsworks to start the CA
 # That's why this recipe is run after kagent::default (responsible for signing the certificates)
@@ -40,7 +42,8 @@ if node['mysql']['tls'].casecmp?("true")
             :mysql_tls => true,
             :certificate => certificate,
             :key => key,
-            :hops_ca => hops_ca
+            :hops_ca => hops_ca,
+            :timezone => Time.now.strftime("%:z")
     })
     notifies :restart, resources(:service => "mysqld"), :immediately
     end

--- a/templates/default/my-ndb.cnf.erb
+++ b/templates/default/my-ndb.cnf.erb
@@ -17,6 +17,8 @@ max-connections = 512
 max-prepared-stmt-count = 65530
 local_infile = OFF
 
+default-time-zone = "<%= @timezone %>"
+
 # Explicit defaults for TS needed by 'airflow initdb'
 explicit_defaults_for_timestamp = 1
 


### PR DESCRIPTION
MySQL fails to start with Timezone `EDT` is unrecognized or represents
more than one timezone. The fix is to set the timezone explicitly.