### PR TITLE
[HOPSWORKS-2647] Add support for Ubuntu 20.04 / Centos 8 (#87)

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -150,6 +150,14 @@ directory node['mysql']['version_dir'] do
   action :create
 end
 
+if node['platform_family'].eql?('rhel')
+  package 'ncurses'
+
+  if node['platform_version'] >= '8'
+    package 'ncurses-compat-libs'
+  end
+end
+
 url = node['ndb']['url']
 Chef::Log.info "Downloading mysql cluster binaries from #{url}"
 base_package_filename = File.basename(node['ndb']['url'])


### PR DESCRIPTION
* Install ncurses for centos8

* Fix syntax

* install ncurses-compact-libs only on centos 8