### PR TITLE
[HOPSWORKS-3174] Bump-up RonDB version to 21.04.6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ include_attribute "kagent"
 
 default['ndb']['majorVersion']                        = "21"
 default['ndb']['minorVersion']                        = "04"
-default['ndb']['patchVersion']                        = "4"
+default['ndb']['patchVersion']                        = "6"
 
 default['ndb']['version']                             = "#{node['ndb']['majorVersion']}.#{node['ndb']['minorVersion']}.#{node['ndb']['patchVersion']}"
 default['ndb']['enabled']                             = "true"


### PR DESCRIPTION
put it back now that the dependencies have been fixed